### PR TITLE
Add versioning endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,38 @@ app = Flask(__name__)
 add_healthcheck(app)
 ```
 
+## Version endpoint
+To add version endpoint to your microservice, first you need to create a configuration
+JSON file in the root of the microservice project, that looks like this:
+
+```json
+{
+    "version": "1.0.0"
+}
+```
+
+After that, add the following code after you create the Flask instance:
+
+```python
+import os 
+from flask import Flask
+from microkubes.tools import add_version_endpoint, read_config
+
+app = Flask(__name__)    
+
+current_dir_path = os.path.dirname(os.path.realpath(__file__))
+config = read_config(current_dir_path + '/config.json')
+add_version_endpoint(app, config)
+```
+
+To test it out, start the Flask server and do `curl http://localhost:5000/version` and it will return:
+
+```json
+{
+    "version": "1.0.0"
+}
+```
+
 ## Contributing
 
 For contributing to this repository or its documentation, see the [Contributing guidelines](CONTRIBUTING.md).

--- a/microkubes/tools/__init__.py
+++ b/microkubes/tools/__init__.py
@@ -1,1 +1,3 @@
 from microkubes.tools.healthcheck import add_healthcheck
+from microkubes.tools.version import add_version_endpoint
+from microkubes.tools.read_config import read_config

--- a/microkubes/tools/read_config.py
+++ b/microkubes/tools/read_config.py
@@ -1,0 +1,27 @@
+"""Read configuration from file
+"""
+
+import sys
+import logging
+import json
+from json.decoder import JSONDecodeError
+
+
+def read_config(config_path):
+    """Read configuration from file.
+
+    :param config_path: ``str``, The config file path.
+
+    :returns: ``dict``, The configuration in a dict format.
+
+    """
+    try:
+        with open(config_path) as json_file:
+            data = json.load(json_file)
+            return data
+    except FileNotFoundError:
+        logging.error('Please provide a valid path for config file.')
+        sys.exit(1)
+    except JSONDecodeError:
+        logging.error('The configuration you provided is not a valid JSON.')
+        sys.exit(1)

--- a/microkubes/tools/version.py
+++ b/microkubes/tools/version.py
@@ -1,0 +1,28 @@
+"""Version endpoint
+"""
+
+import json
+import logging
+import sys
+
+
+def add_version_endpoint(app, config):
+    """Adds Flask endpoint that returns the microservice version.
+
+    :param app: ``Flask``, Flask app instance.
+    :param config: ``dict``, The configuration in a dict format.
+
+    """
+    version = config.get('version')
+
+    if version is None:
+        logging.error('Field "version" does not exist in the configuration file.')
+        sys.exit(1)
+
+    def _version_endpoint():
+        version_dict = {
+            'version': version
+        }
+        return json.dumps(version_dict)
+
+    app.route('/version')(_version_endpoint)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -148,7 +148,7 @@ class TestACLProvider(TestCase):
     @mock.patch('microkubes.security.chain.Request.path', new_callable=mock.PropertyMock)
     @mock.patch.object(Request, 'get_header')
     def test_acl_provider(self, get_header_mock, path_mock, method_mock):
-        method_mock.return_value = 'GET'
+        method_mock.return_value = 'POST'
         path_mock.return_value = '/todos'
 
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
This PR adds a Flask endpoint for returning the current version of a microservice based on a config file, as well as a documentation on how to integrate it in a Flask application.